### PR TITLE
Fix entry point and Docker run command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
 # Run the application
-CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "main.py"]

--- a/main.py
+++ b/main.py
@@ -1163,7 +1163,15 @@ class SlackMCPServer:
         """Run the FastMCP server"""
         self.mcp.run(**kwargs)
 
-# Create and run the server
+# Initialize server instance and ASGI app for Uvicorn
+server = SlackMCPServer()
+app = server.mcp.http_app()
+
+
+def main() -> None:
+    """Entry point for running the Slack MCP server."""
+    server.run(transport="streamable-http", host=os.getenv("HOST", "0.0.0.0"), port=int(os.getenv("PORT", "8000")))
+
+
 if __name__ == "__main__":
-    server = SlackMCPServer()
-    server.run()
+    main()


### PR DESCRIPTION
## Summary
- expose Slack MCP server as ASGI `app`
- add `main()` function for console scripts
- run server directly in Docker

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685967fc99608325b379f5ea4f913063